### PR TITLE
docs: registrar plan maestro para version JavaFX

### DIFF
--- a/docs/API_CONFIG.md
+++ b/docs/API_CONFIG.md
@@ -1,0 +1,90 @@
+# Configuración de Conexión a la API - Miet20 Desktop
+
+## Archivo de configuración externo
+
+- Ruta sugerida: `config/application.json` (editable por despliegue).
+- Ejemplo:
+  ```json
+  {
+    "apiBaseUrl": "https://api.miet20.test/api/v1",
+    "timeoutMs": 10000,
+    "connectRetryMs": 2000,
+    "notificationsRefreshMs": 60000
+  }
+  ```
+- Mantener el sufijo `/api/v1` para respetar el versionado de la API.
+
+## Clase `ApiConfig`
+
+- Responsabilidades:
+  - Leer el archivo JSON usando `Files.readString(Path.of("config/application.json"))`.
+  - Mapear a un POJO/record (`record ApiSettings(String apiBaseUrl, int timeoutMs, int connectRetryMs, int notificationsRefreshMs)`).
+  - Exponer getters y permitir recarga (releer cuando se detecte cambio o se solicite manualmente).
+  - Validar formato de URL y tiempos mayores a cero.
+
+## Cliente HTTP reutilizable (`ApiClient`)
+
+- Basado en `java.net.http.HttpClient` configurado con:
+  - `connectTimeout` usando `timeoutMs`.
+  - `Executor` dedicado para peticiones.
+  - `Version.HTTP_2` si el backend lo soporta.
+- Métodos helper: `sendGet`, `sendPost`, `sendPut`, `sendDelete` que reciben ruta relativa y payload opcional.
+- Manejo de errores:
+  - 401 → invocar `TokenManager.refresh()` y reintentar una sola vez.
+  - 4xx → lanzar excepción custom (`ApiClientException`) con detalle del cuerpo.
+  - 5xx → mostrar mensaje de mantenimiento y registrar logs.
+
+## Token Manager
+
+- Almacena `accessToken`, `refreshToken`, expiraciones.
+- Persistencia opcional en archivo cifrado si se requiere “recordarme”.
+- API:
+  - `setTokens(TokenResponse response)`.
+  - `getAuthorizationHeader()`.
+  - `refreshIfNeeded()`.
+
+## Servicios de ejemplo
+
+### HealthService
+```java
+public class HealthService {
+    private final ApiClient apiClient;
+
+    public HealthService(ApiClient apiClient) {
+        this.apiClient = apiClient;
+    }
+
+    public HealthStatus check() {
+        HttpResponse<String> response = apiClient.sendGet("/health");
+        return objectMapper.readValue(response.body(), HealthStatus.class);
+    }
+}
+```
+
+### AuthService
+```java
+public class AuthService {
+    private final ApiClient apiClient;
+    private final TokenManager tokenManager;
+
+    public AuthService(ApiClient apiClient, TokenManager tokenManager) {
+        this.apiClient = apiClient;
+        this.tokenManager = tokenManager;
+    }
+
+    public UserSession login(String email, String password) {
+        LoginRequest request = new LoginRequest(email, password);
+        HttpResponse<String> response = apiClient.sendPost("/auth/login", request);
+        LoginResponse loginResponse = objectMapper.readValue(response.body(), LoginResponse.class);
+        tokenManager.setTokens(loginResponse.tokens());
+        return loginResponse.userSession();
+    }
+}
+```
+
+## Versionado
+
+- Validar que `HealthStatus.version()` sea `"v1"`.
+- Si se publica `v2`, el archivo de configuración debe actualizarse (`"https://api.miet20.test/api/v2"`).
+- Mantener constantes en un solo lugar para evitar hardcodear rutas en la UI.
+

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1,0 +1,60 @@
+# Seguimiento de Módulos Funcionales - Miet20 Desktop
+
+Utiliza este documento para marcar el avance por módulo.
+
+## Dashboard
+- [ ] Definir contratos de API (`/dashboard/metrics`).
+- [ ] Implementar `DashboardService`.
+- [ ] Crear `DashboardViewModel` y bindings.
+- [ ] Diseñar `dashboard.fxml` con cards y gráficos.
+- [ ] Pruebas unitarias de servicio.
+- [ ] Pruebas manuales/UI.
+
+## Noticias
+- [ ] Revisar endpoints (`/news`, `/news/{id}`).
+- [ ] Implementar `NewsService` con soporte de imágenes.
+- [ ] Crear `NewsListViewModel`, `NewsDetailViewModel`.
+- [ ] Diseñar vistas (`news_list.fxml`, `news_detail.fxml`, `news_form.fxml`).
+- [ ] Manejar subida de archivos.
+- [ ] Pruebas unitarias e integración.
+
+## Alumnos
+- [ ] Consumir `/students` con filtros/paginación.
+- [ ] Implementar `StudentService`.
+- [ ] Crear tabla JavaFX con `TableView` y filtros.
+- [ ] Diseñar formularios (`student_form.fxml`).
+- [ ] Validaciones y feedback de errores.
+- [ ] Pruebas.
+
+## Cursos y Asignaturas
+- [ ] Endpoints `/courses`, `/subjects`.
+- [ ] Servicios y viewmodels.
+- [ ] Vista jerárquica (`TreeTableView`).
+- [ ] Pruebas.
+
+## Asistencias
+- [ ] Endpoints `/attendance`.
+- [ ] Servicios, viewmodels, vistas.
+- [ ] Reportes/exportación.
+- [ ] Pruebas.
+
+## Notas
+- [ ] Endpoints `/grades`.
+- [ ] Servicios, viewmodels, formularios.
+- [ ] Validaciones y reportes.
+- [ ] Pruebas.
+
+## Notificaciones
+- [ ] Revisar endpoints y potencial WebSocket.
+- [ ] Migrar UI Swing a JavaFX (`notifications.fxml`).
+- [ ] Integrar filtros, búsqueda, paginación.
+- [ ] Integración con sistema de alertas.
+- [ ] Pruebas.
+
+## Otros (Configuraciones, Archivos, etc.)
+- [ ] Carga de archivos (`/files`).
+- [ ] Gestión de roles (`/roles`, `/permissions`).
+- [ ] Preferencias de usuario (`/settings`).
+- [ ] Accesibilidad (teclado, temas de alto contraste).
+- [ ] Documentación adicional.
+

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -1,0 +1,200 @@
+# Proyecto Miet20 - Plan Maestro para Aplicación de Escritorio JavaFX
+
+## 0. Mapeo del Repositorio
+
+- [x] **Raíz del proyecto**: artefactos heredados (`build`, `dist`), configuración NetBeans (`nbproject`), bibliotecas (`lib`), manifiesto (`manifest.mf`) e íconos.
+- [x] **Aplicación de escritorio existente (Swing)**: código en `src/main/java`, entrada `Main`, componentes como `NotificationUI`.
+- [x] **Aplicación web y API**: `miet20webAPI/public` (frontend web con Tailwind) y `miet20webAPI/api` (Node/Express, entry `src/server.js`, rutas versionadas `/api/v1`, especificación OpenAPI en `api/openapi.yaml`).
+
+> ✅ **Checkpoint 0 completado:** Conocimiento inicial del repositorio y alcance global.
+
+---
+
+## 1. Fundaciones del Proyecto JavaFX
+
+**Objetivo:** Crear la base del proyecto de escritorio moderno usando JavaFX.
+
+### Tareas
+- [ ] Inicializar proyecto Gradle/Maven para JavaFX (JDK 21 recomendado).
+- [ ] Crear estructura de paquetes:
+  - `com.miet20.app` (entry point JavaFX, `MainApp`).
+  - `com.miet20.config` (configuraciones, carga de archivos externos).
+  - `com.miet20.services` (consumo de API, clientes HTTP).
+  - `com.miet20.viewmodels` (lógica de presentación, `ObservableProperty`).
+  - `com.miet20.ui` (controladores JavaFX).
+  - `com.miet20.ui.components` (componentes reutilizables).
+  - `com.miet20.resources` (FXML, CSS, imágenes).
+- [ ] Configurar dependencias: JavaFX (Controls, FXML), Jackson, HTTP Client (JDK), ControlsFX, TestFX (test), JUnit 5, MockWebServer.
+- [ ] Añadir configuración `gradle.properties` para JavaFX modular y `build.gradle` con tasks `run`, `test`, `jpackage`.
+- [ ] Definir plantilla de recursos (`resources/application.json`, `resources/styles/theme.css`).
+
+### Entregables de la etapa
+- Proyecto compilable con `gradle run` que abre ventana base vacía.
+- Documentación mínima (`README_DESKTOP.md`) con instrucciones para ejecutar.
+
+> ⏭️ **Próximo checkpoint:** Proyecto JavaFX base creado y ejecutándose (`gradle run`).
+
+---
+
+## 2. Infraestructura de Red y Configuración
+
+**Objetivo:** Implementar la capa de acceso a la API REST.
+
+### Tareas
+- [ ] Crear `config/application.json` con parámetros `apiBaseUrl`, `timeoutMs`, etc.
+- [ ] Implementar `ApiConfig` que lea el archivo y permita reconfigurar la URL.
+- [ ] Implementar `ApiClient` basado en `java.net.http.HttpClient` con manejo de encabezados y errores.
+- [ ] Implementar `TokenManager` (persistencia en memoria y disco opcional) para `access` y `refresh` tokens.
+- [ ] Crear `HealthService` para verificar `/health` y validar versión (`v1`).
+- [ ] Añadir pruebas unitarias con `MockWebServer` para validar escenarios de red.
+
+### Entregables
+- Código capaz de consumir `/health` y reportar estado en consola/UI.
+- Documentación de configuración (`docs/API_CONFIG.md`).
+
+> ⏭️ **Checkpoint:** `HealthService` muestra versión compatible y maneja errores de conectividad.
+
+---
+
+## 3. Autenticación y Gestión de Sesión
+
+**Objetivo:** Replicar el flujo de login de la web.
+
+### Tareas
+- [ ] Diseñar vista FXML de login (`resources/fxml/login.fxml`) con estilos de la web.
+- [ ] Crear CSS (`resources/styles/login.css`) con gradientes y tipografías equivalentes.
+- [ ] Implementar `LoginViewModel` con bindings (email, password, loading, error).
+- [ ] Integrar `AuthService` (`POST /auth/login`, `/auth/google-login` si aplica).
+- [ ] Manejar tokens y persistir sesión con `TokenManager`.
+- [ ] Implementar recordatorios de contraseña/enlaces.
+
+### Entregables
+- Pantalla de login funcional que accede a la API real (sandbox) y navega al shell principal.
+
+> ⏭️ **Checkpoint:** Login exitoso actualiza vista y guarda tokens.
+
+---
+
+## 4. Navegación Principal y Shell
+
+**Objetivo:** Construir la estructura base de navegación.
+
+### Tareas
+- [ ] Diseñar shell principal (`MainAppShell.fxml`) con sidebar, header y contenedor central.
+- [ ] Crear componentes: `SidebarView`, `HeaderView`, `ContentRouter`.
+- [ ] Implementar navegación interna con `RouterService` y `ViewLoader` (FXML cacheado).
+- [ ] Aplicar estilos responsive (colapso de sidebar en ventanas pequeñas).
+- [ ] Integrar estado del usuario (nombre, avatar) en header.
+
+### Entregables
+- Shell que permita cambiar entre vistas placeholder (Dashboard, Alumnos, Noticias, Ajustes).
+
+> ⏭️ **Checkpoint:** Navegación fluida entre módulos y diseño responsive básico.
+
+---
+
+## 5. Módulos Funcionales Clave
+
+**Objetivo:** Replicar las funcionalidades principales de la web.
+
+### Iteraciones (repetir para cada módulo prioritario)
+1. **Dashboard**
+   - [ ] Servicio `DashboardService` (`/dashboard/metrics`).
+   - [ ] Cards y gráficos (usar `ChartsFX` o `JavaFX Charts`).
+   - [ ] Animaciones/indicadores de carga.
+
+2. **Noticias**
+   - [ ] Listar noticias (`/news`).
+   - [ ] Detalle y creación/edición con formularios y subida de imágenes.
+
+3. **Alumnos**
+   - [ ] Tabla con paginación (`/students`).
+   - [ ] Formulario de alta y edición (`/students/{id}`).
+
+4. **Cursos/Asignaturas**
+   - [ ] Árbol o tabla jerárquica (`/courses`, `/subjects`).
+
+5. **Asistencias**
+   - [ ] Registro y reportes (`/attendance`).
+
+6. **Notas**
+   - [ ] Ingreso y consulta (`/grades`).
+
+7. **Notificaciones**
+   - [ ] Migrar `NotificationUI` a JavaFX, integración con `/notifications`.
+
+### Entregables por módulo
+- Servicio API, ViewModel, vista JavaFX, pruebas unitarias (servicio) y manuales (UI).
+- Documentar particularidades en `docs/MODULES.md`.
+
+> ⏭️ **Checkpoint general:** Cada módulo clave en producción tiene checkboxes individuales completados en `docs/MODULES.md`.
+
+---
+
+## 6. Notificaciones y Tiempo Real
+
+**Objetivo:** Experiencia moderna de notificaciones.
+
+### Tareas
+- [ ] Implementar polling o WebSocket según API.
+- [ ] Crear componente JavaFX de lista expandible con filtros.
+- [ ] Integrar con sistema de alertas en la app (toasts).
+- [ ] Añadir configuración de intervalo en `application.json`.
+
+> ⏭️ **Checkpoint:** Notificaciones en tiempo (semi)real funcionando y UI migrada desde Swing.
+
+---
+
+## 7. Configuraciones, Archivos y Extras
+
+**Objetivo:** Cobertura de funcionalidades restantes.
+
+### Tareas
+- [ ] Implementar subida de archivos (`/files`) con progreso.
+- [ ] Sección de configuración de usuario y roles.
+- [ ] Formularios avanzados (validación, autocompletado).
+- [ ] Accesibilidad (soporte teclado, contraste).
+
+> ⏭️ **Checkpoint:** Todos los flujos secundarios completados y documentados.
+
+---
+
+## 8. Pruebas, Documentación y Empaquetado
+
+**Objetivo:** Garantizar calidad y entrega.
+
+### Tareas
+- [ ] Diseñar plan de pruebas (unitarias, integración, UI) y ejecutarlo.
+- [ ] Configurar CI (GitHub Actions) para `gradle build`, `gradle test`, API lint.
+- [ ] Preparar empaquetado con `jpackage` para Windows (EXE/MSI) y guía de instalación.
+- [ ] Elaborar manual de usuario y administrador.
+
+> ⏭️ **Checkpoint final:** Build empaquetado, documentación final entregada y checklist de smoke tests firmado.
+
+---
+
+## Apéndices
+
+### A. Integración API ↔ JavaFX (Resumen Técnico)
+- `ApiConfig` carga `config/application.json`.
+- `ApiClient` construye URLs manteniendo `/api/v1`.
+- Servicios usan `ObjectMapper` de Jackson para serializar/deserializar.
+- ViewModels actualizan la UI mediante `Platform.runLater`.
+- Tokens gestionados por `TokenManager` con refresh automático.
+
+### B. Coherencia Visual
+- Estilos centralizados en `resources/styles/theme.css` replicando Tailwind (colores, tipografía `Inter`).
+- Componentes reutilizables (botones, tarjetas, tablas) definen clases CSS (`.btn-primary`, `.card`, `.badge`).
+- Uso de `FontAwesomeFX` para iconografía similar al web.
+
+### C. Plan de Pruebas (Resumen)
+- Unitarias: `ApiConfigTest`, `AuthServiceTest`, `StudentServiceTest`, etc.
+- Integración: pruebas contra API en sandbox.
+- UI: TestFX para flujos críticos.
+- Manual: checklist de smoke test.
+
+### D. Empaquetado Windows
+- `gradle jpackage --type exe` con ícono `logo_et20_max.ico`.
+- Incluir `config/application.json` editable.
+- Documentar pasos en `docs/DEPLOY_WINDOWS.md` (a crear en etapa 8).
+


### PR DESCRIPTION
## Summary
- add a comprehensive project roadmap for the new JavaFX desktop version, including checkpoints per stage
- document module-specific task lists to track progress through each major feature area
- capture API integration configuration guidelines with examples for client and token management

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d58cecfbd083308a97fe560a1f960d